### PR TITLE
Address race condition in deleting a connection and checking if it is alive

### DIFF
--- a/cluster-manager/app/workers.py
+++ b/cluster-manager/app/workers.py
@@ -217,7 +217,7 @@ class VlanWorker(threading.Thread):
             connection = DB.Connection(addr)
 
             # If this connection is not alive, this worker reacted to the connection being killed
-            if connection.alive:
+            if connection.exists() and connection.alive:
                 user = connection.user
                 vpn = connection.vpn
 


### PR DESCRIPTION
A true fix would be best implemented in `trol`

Closes: #11 