### PR TITLE
Remove Version Requirement for Easy RSA

### DIFF
--- a/registrar/Dockerfile
+++ b/registrar/Dockerfile
@@ -4,7 +4,7 @@ COPY ./requirements.txt ./requirements.txt
 RUN pip install -r ./requirements.txt
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --no-cache --update bash 'easy-rsa<3.0.4'
+    apk add --no-cache --update bash 'easy-rsa'
 ENV EASYRSA=/usr/share/easy-rsa/
 
 COPY ./app /app


### PR DESCRIPTION
Having the version requirement causes the build to break every time Easy RSA has a new release.